### PR TITLE
Fix V575 warning from PVS-Studio Static Analyzer

### DIFF
--- a/lightmf-test.cpp
+++ b/lightmf-test.cpp
@@ -45,15 +45,15 @@ int parse_cmd_line(int argc, char *const argv[]){
         switch (option) {
             case 0:
                 opt->flags |= FLAG_MODEL;
-                memcpy(opt->model, optarg, strlen(optarg));
+                strcpy(opt->model, optarg);
                 break;
             case 1:
                 opt->flags |= FLAG_TEST;
-                memcpy(opt->test, optarg, strlen(optarg));
+                strcpy(opt->test, optarg);
                 break;
             case 2:
                 opt->flags |= FLAG_OUTPUT;
-                memcpy(opt->output, optarg, strlen(optarg));
+                strcpy(opt->output, optarg);
                 break;
             case 3:
                 opt->flags |= FLAG_HELP;

--- a/lightmf-train.cpp
+++ b/lightmf-train.cpp
@@ -60,11 +60,11 @@ int parse_cmd_line(int argc, char *const argv[]){
         switch (option) {
             case 0:
                 opt->flags |= FLAG_TRAIN;
-                memcpy(opt->train, optarg, strlen(optarg));
+                strcpy(opt->train, optarg);
                 break;
             case 1:
                 opt->flags |= FLAG_MODEL;
-                memcpy(opt->model, optarg, strlen(optarg));
+                strcpy(opt->model, optarg);
                 break;
             case 2:
                 opt->flags |= FLAG_TYPE;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The 'memcpy' function doesn't copy the whole string.
Use 'strcpy / strcpy_s' function to preserve terminal null.