### PR TITLE
Fix V773 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/LatentFactorModel.cpp
+++ b/LatentFactorModel.cpp
@@ -181,6 +181,8 @@ bool LatentFactorModel::load(string path){
     is.open(meta_file.c_str(), ios::in);
 
     if(!is.good()){ 
+        delete rows;
+        delete cols;
         throw runtime_error(meta_file + " not exist"); 
     }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The exception was thrown without releasing the 'rows' pointer.
A memory leak is possible.
The exception was thrown without releasing the 'cols' pointer.
A memory leak is possible.